### PR TITLE
Added prettier-plugin-tailwindcss

### DIFF
--- a/frontendV2/.prettierrc.cjs
+++ b/frontendV2/.prettierrc.cjs
@@ -3,4 +3,5 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
+  plugins: ['prettier-plugin-tailwindcss'],
 };

--- a/frontendV2/package-lock.json
+++ b/frontendV2/package-lock.json
@@ -51,6 +51,7 @@
         "jsdom": "^22.1.0",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
+        "prettier-plugin-tailwindcss": "^0.5.5",
         "tailwindcss": "^3.3.3",
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
@@ -5819,6 +5820,78 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.5.tgz",
+      "integrity": "sha512-voy0CjWv/CM8yeaduv5ZwovovpTGMR5LbzlhGF+LtEvMJt9wBeVTVnW781hL38R/RcDXCJwN2rolsgr94B/n0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@shufo/prettier-plugin-blade": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@shufo/prettier-plugin-blade": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "prettier-plugin-twig-melody": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {
@@ -11723,6 +11796,13 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.5.5.tgz",
+      "integrity": "sha512-voy0CjWv/CM8yeaduv5ZwovovpTGMR5LbzlhGF+LtEvMJt9wBeVTVnW781hL38R/RcDXCJwN2rolsgr94B/n0Q==",
+      "dev": true,
+      "requires": {}
     },
     "pretty-format": {
       "version": "29.7.0",

--- a/frontendV2/package.json
+++ b/frontendV2/package.json
@@ -57,6 +57,7 @@
     "jsdom": "^22.1.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
+    "prettier-plugin-tailwindcss": "^0.5.5",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",


### PR DESCRIPTION
## Why was this PR opened?

To add consistency with tailwind CSS classes.

## Brief Description

This PR adds a prettier plugin that automatically sorts tailwind classes to help keep pages/components consistent with one another. When you save a file, the plugin will run and sort all tailwind CSS classes based on their [recommended order.](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted) You can learn more about the plugin [here.](https://github.com/tailwindlabs/prettier-plugin-tailwindcss)

## Unrelated Changes

## UI Screenshots

## Link to Referenced Trello Cards

## Mentions
