### PR TITLE
Houf 117 - Refactor Register Page

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -18,7 +18,12 @@ export const registerUser = async (req, res) => {
     // Generate a JWT token
     const token = newUser.generateToken();
 
-    return res.status(201).json({ token });
+    return res.status(201).json({
+      token,
+      id: newUser._id,
+      email: newUser.email,
+      role: newUser.role,
+    });
   } catch (error) {
     return res.status(500).json({ message: 'Server error' });
   }

--- a/frontendV2/package-lock.json
+++ b/frontendV2/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^3.3.1",
         "@radix-ui/react-aspect-ratio": "^1.0.3",
+        "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
@@ -794,6 +795,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz",
+      "integrity": "sha512-CBuGQa52aAYnADZVt/KBQzXrwx6TqnlwtcIPGtVt5JkkzQwMOLJjPukimhfKEr4GQNd43C+djUh5Ikopj8pSLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
@@ -1336,6 +1367,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
       "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },

--- a/frontendV2/package.json
+++ b/frontendV2/package.json
@@ -13,10 +13,11 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.1",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
+    "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
-    "@hookform/resolvers": "^3.3.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",

--- a/frontendV2/src/api/auth/authApi.ts
+++ b/frontendV2/src/api/auth/authApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import { Credentials, UserResponse } from '@constants/types';
+import { Credentials, RegisterResponse, UserResponse } from '@constants/types';
 
 const baseQuery = fetchBaseQuery({
   baseUrl: import.meta.env.VITE_BASE_URL,
@@ -17,7 +17,22 @@ export const authApi = createApi({
       }),
       invalidatesTags: ['User'],
     }),
+    register: builder.mutation<RegisterResponse, Credentials>({
+      query: (credentials) => ({
+        url: '/api/users/register',
+        method: 'POST',
+        body: credentials,
+      }),
+      // transformResponse(baseQueryReturnValue) {
+      //   return {
+      //     token: baseQueryReturnValue.token,
+      //   };
+      // },
+      transformErrorResponse(baseQueryReturnValue) {
+        return baseQueryReturnValue.data;
+      },
+    }),
   }),
 });
 
-export const { useLoginMutation } = authApi;
+export const { useLoginMutation, useRegisterMutation } = authApi;

--- a/frontendV2/src/api/auth/authApi.ts
+++ b/frontendV2/src/api/auth/authApi.ts
@@ -23,11 +23,14 @@ export const authApi = createApi({
         method: 'POST',
         body: credentials,
       }),
-      // transformResponse(baseQueryReturnValue) {
-      //   return {
-      //     token: baseQueryReturnValue.token,
-      //   };
-      // },
+      transformResponse(baseQueryReturnValue: RegisterResponse) {
+        return {
+          id: baseQueryReturnValue.id,
+          email: baseQueryReturnValue.email,
+          role: baseQueryReturnValue.role,
+          token: baseQueryReturnValue.token,
+        };
+      },
       transformErrorResponse(baseQueryReturnValue) {
         return baseQueryReturnValue.data;
       },

--- a/frontendV2/src/components/ui/checkbox.tsx
+++ b/frontendV2/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon } from "@radix-ui/react-icons"
+
+import { cn } from "@/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <CheckIcon className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/frontendV2/src/components/ui/form.tsx
+++ b/frontendV2/src/components/ui/form.tsx
@@ -4,6 +4,7 @@ import { Slot } from '@radix-ui/react-slot';
 import {
   Controller,
   ControllerProps,
+  FieldErrors,
   FieldPath,
   FieldValues,
   FormProvider,
@@ -161,6 +162,21 @@ const FormMessage = React.forwardRef<
 });
 FormMessage.displayName = 'FormMessage';
 
+const FormRootErrorMessage = React.forwardRef<
+  HTMLParagraphElement,
+  { errors: FieldErrors<FieldValues> } & React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  return (
+    <>
+      {props.errors.root &&
+        <FormErrorMessage ref={ref} {...props}>
+          {props.errors.root.message}
+        </FormErrorMessage>}
+    </>
+  );
+});
+FormRootErrorMessage.displayName = 'FormRootErrorMessage';
+
 const FormErrorMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
@@ -186,5 +202,6 @@ export {
   FormDescription,
   FormMessage,
   FormErrorMessage,
+  FormRootErrorMessage,
   FormField,
 };

--- a/frontendV2/src/components/ui/form.tsx
+++ b/frontendV2/src/components/ui/form.tsx
@@ -154,17 +154,28 @@ const FormMessage = React.forwardRef<
   }
 
   return (
-    <p
-      ref={ref}
-      id={formMessageId}
-      className={cn('text-[0.8rem] font-medium text-destructive', className)}
-      {...props}
-    >
+    <FormErrorMessage id={formMessageId} ref={ref} {...props}>
       {body}
-    </p>
+    </FormErrorMessage>
   );
 });
 FormMessage.displayName = 'FormMessage';
+
+const FormErrorMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  return (
+    <p
+      ref={ref}
+      className={cn('text-[0.8rem] font-medium text-destructive', className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+});
+FormErrorMessage.displayName = 'FormErrorMessage';
 
 export {
   useFormField,
@@ -174,5 +185,6 @@ export {
   FormControl,
   FormDescription,
   FormMessage,
+  FormErrorMessage,
   FormField,
 };

--- a/frontendV2/src/constants/types.ts
+++ b/frontendV2/src/constants/types.ts
@@ -3,6 +3,10 @@ export type Credentials = {
   password: string;
 };
 
+export type RegisterResponse = User & {
+  token: string;
+};
+
 export type User = {
   id: string;
   email: string;


### PR DESCRIPTION
## Why was this PR opened?

To migrate the register page from Bootstrap to TailwindCSS.

## Brief Description

- Refactored the register screen to use Tailwind instead of Bootstrap
- We are now using the PasswordShowContext to enable users to toggle the visibility of their password

## Unrelated Changes

- Implemented the register endpoint for RTK Query
- Modified the return result of the backend register endpoint to return information about the newly created user
  - This was needed for redux to function, store information about the user ID, email, and role
- Added ShadCN Checkbox (https://ui.shadcn.com/docs/components/checkbox)

## UI Screenshots

## Link to Referenced Trello Cards

https://tosinbabatope.atlassian.net/jira/software/c/projects/HOUF/boards/3?selectedIssue=HOUF-117

## Mentions
