### PR TITLE
Houf 127 Redesign Header

### DIFF
--- a/frontendV2/src/components/Header/Header.tsx
+++ b/frontendV2/src/components/Header/Header.tsx
@@ -13,6 +13,7 @@ import {
 } from '@components/ui/dropdown';
 
 import { Cross2Icon } from '@radix-ui/react-icons';
+import { useLocation } from 'react-router-dom';
 import {
   Sheet,
   SheetClose,
@@ -21,15 +22,41 @@ import {
   SheetPrimitiveContent,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+
+export type MenuItem = {
+  title: string;
+  href: string;
+};
+
+const menuItems: MenuItem[] = [
+  {
+    title: 'Profiles',
+    href: '/profiles',
+  },
+  {
+    title: 'History',
+    href: '/history',
+  },
+  {
+    title: 'Bookmark',
+    href: '/bookmark',
+  },
+  {
+    title: 'FAQ',
+    href: '/faq',
+  },
+];
 
 export default function Header() {
   const { userInfo } = useAppSelector((state) => state.auth);
   const { handleLogout } = useAuth();
+  const location = useLocation();
 
   return (
     <header>
-      <div className="sticky top-0 z-50 border-b border-gray-200 bg-gray-300 px-9">
-        <div className="flex h-28 items-center justify-between space-x-3">
+      <div className="sticky top-0 z-40 bg-gray-300 px-9">
+        <div className="flex h-20 items-center justify-between space-x-3">
           <a
             href="/"
             className="flex items-center space-x-2 text-lg font-bold text-gray-700 hover:text-gray-900"
@@ -38,7 +65,7 @@ export default function Header() {
             <p>HouseFinder</p>
           </a>
 
-          <div className="lg:hidden">
+          <div className="md:hidden">
             <Sheet>
               <SheetTrigger asChild>
                 <Menu className="h-6 w-6 hover:text-gray-500" />
@@ -52,9 +79,7 @@ export default function Header() {
                   <ol className="flex flex-col items-end space-y-4 pr-8 pt-12 text-2xl font-bold">
                     <a href="/">Profile</a>
                     {userInfo ? (
-                      <a href="/" onClick={handleLogout}>
-                        Logout
-                      </a>
+                      <a href="/">Logout</a>
                     ) : (
                       <>
                         <a href="/login">Login</a>
@@ -71,14 +96,31 @@ export default function Header() {
             </Sheet>
           </div>
 
-          <div className="hidden lg:mx-auto lg:flex lg:w-auto lg:items-center lg:space-x-6">
-            <a className="hover:text-gray-900" href="/faq">
-              FAQ
-            </a>
-            <a className="hover:text-gray-900" href="/demo">
-              Scoring Demo
-            </a>
-            {userInfo?.email ? (
+          <div className="hidden h-full w-full items-center justify-between md:flex">
+            <div className="flex h-full space-x-6 px-9">
+              {menuItems.map((menuItem) => {
+                return (
+                  <div className="relative flex h-full w-24 items-center justify-center hover:bg-red-500">
+                    {/* {location.pathname.startsWith(menuItem.href) && ( */}
+                    <div className="absolute top-[calc(50%+34px)] z-50 h-1.5 w-full bg-orange-500" />
+                    {/* )} */}
+                    <div>{menuItem.title}</div>
+                  </div>
+                  // <a
+                  //   key={menuItem.href}
+                  //   href={menuItem.href}
+                  //   className={cn(
+                  //     'flex h-full w-24 items-center justify-center hover:border-b-8 hover:border-b-blue-600 hover:bg-red-500 hover:text-gray-900',
+                  //     location.pathname.startsWith(menuItem.href) &&
+                  //       'hover:text-gray-900'
+                  //   )}
+                  // >
+                  //   {menuItem.title}
+                  // </a>
+                );
+              })}
+            </div>
+            {userInfo ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <div className="flex items-center justify-center text-gray-500 hover:cursor-pointer hover:text-gray-600">
@@ -90,22 +132,25 @@ export default function Header() {
                   <DropdownMenuSeparator />
                   <DropdownMenuGroup>
                     <DropdownMenuItem>
-                      <a href="/" className="flex gap-1">
-                        <User className="mr-2 h-4 w-4" />
-                        Profile
-                      </a>
+                      <User className="mr-2 h-4 w-4" />
+                      <a href="/">Profile</a>
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem>
-                    <a href="/" className="flex gap-1" onClick={handleLogout}>
-                      <LogOut className="mr-2 h-4 w-4" />
+                    <LogOut className="mr-2 h-4 w-4" />
+                    <a href="/" onClick={handleLogout}>
                       Log out
                     </a>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
+              // <a href="/login" className="flex gap-1">
+              //   <UserCircle className="h-7 w-7" />
+              //   Login
+              // </a>
+
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <div className="flex items-center justify-center text-gray-500 hover:cursor-pointer hover:text-gray-600">

--- a/frontendV2/src/components/Header/Header.tsx
+++ b/frontendV2/src/components/Header/Header.tsx
@@ -61,7 +61,12 @@ export default function Header() {
             href="/"
             className="flex items-center space-x-2 text-lg font-bold text-gray-700 hover:text-gray-900"
           >
-            <img width={40} src={logo} alt="HouseFinder" />
+            <img
+              width={40}
+              src={logo}
+              alt="HouseFinder"
+              className="rounded-sm"
+            />
             <p>HouseFinder</p>
           </a>
 

--- a/frontendV2/src/components/Header/Header.tsx
+++ b/frontendV2/src/components/Header/Header.tsx
@@ -155,16 +155,22 @@ export default function Header() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                   <DropdownMenuGroup>
-                    <DropdownMenuItem>
-                      <a href="/login" className="flex gap-1">
+                    <DropdownMenuItem asChild>
+                      <a
+                        href="/login"
+                        className="flex gap-1 hover:cursor-pointer"
+                      >
                         <User className="mr-2 h-4 w-4" />
                         Login
                       </a>
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem>
-                    <a href="/register" className="flex gap-1">
+                  <DropdownMenuItem asChild>
+                    <a
+                      href="/register"
+                      className="flex gap-1 hover:cursor-pointer"
+                    >
                       <UserPlus2 className="mr-2 h-4 w-4" />
                       Register
                     </a>

--- a/frontendV2/src/components/Header/Header.tsx
+++ b/frontendV2/src/components/Header/Header.tsx
@@ -100,23 +100,19 @@ export default function Header() {
             <div className="flex h-full space-x-6 px-9">
               {menuItems.map((menuItem) => {
                 return (
-                  <div className="relative flex h-full w-24 items-center justify-center hover:bg-red-500">
-                    {/* {location.pathname.startsWith(menuItem.href) && ( */}
-                    <div className="absolute top-[calc(50%+34px)] z-50 h-1.5 w-full bg-orange-500" />
-                    {/* )} */}
+                  <a
+                    href={menuItem.href}
+                    className={cn(
+                      'relative flex h-full w-24 items-center justify-center hover:bg-gray-400',
+                      location.pathname.startsWith(menuItem.href) &&
+                        'bg-gray-400'
+                    )}
+                  >
+                    {location.pathname.startsWith(menuItem.href) && (
+                      <div className="absolute top-[calc(50%+34px)] z-50 h-1.5 w-full bg-gray-500" />
+                    )}
                     <div>{menuItem.title}</div>
-                  </div>
-                  // <a
-                  //   key={menuItem.href}
-                  //   href={menuItem.href}
-                  //   className={cn(
-                  //     'flex h-full w-24 items-center justify-center hover:border-b-8 hover:border-b-blue-600 hover:bg-red-500 hover:text-gray-900',
-                  //     location.pathname.startsWith(menuItem.href) &&
-                  //       'hover:text-gray-900'
-                  //   )}
-                  // >
-                  //   {menuItem.title}
-                  // </a>
+                  </a>
                 );
               })}
             </div>
@@ -146,11 +142,6 @@ export default function Header() {
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
-              // <a href="/login" className="flex gap-1">
-              //   <UserCircle className="h-7 w-7" />
-              //   Login
-              // </a>
-
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <div className="flex items-center justify-center text-gray-500 hover:cursor-pointer hover:text-gray-600">


### PR DESCRIPTION
## Why was this PR opened?

To make the Header component more in line with the Figma design.

## Brief Description

Refactored the header to enhance the visibility of navigation links for users. Now, when a user is on a particular page or is hovering over a navigation link, the corresponding button is highlighted. Additionally, the House Finder logo was updated to have a small rounded border.

Note: All the colors are currently in grayscale, but this will be changed when the design is finalized and a color pallet has been chosen.

## Unrelated Changes

## UI Screenshots

## Link to Referenced Trello Cards

https://tosinbabatope.atlassian.net/browse/HOUF-127

## Mentions
